### PR TITLE
Fixing getDateTime adding missing TimeZone UTC

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/utils/RapidFtrDateTime.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/utils/RapidFtrDateTime.java
@@ -34,7 +34,7 @@ public class RapidFtrDateTime {
     }
 
     public static Calendar getDateTime(String dateTime) throws ParseException {
-        Calendar calendar = Calendar.getInstance();
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         SimpleDateFormat simpleDateFormat = getDefaultSimpleDateFormat();
         calendar.setTime(simpleDateFormat.parse(dateTime));
         return calendar;


### PR DESCRIPTION
When I ran the tests, one of them were broken because of the time zone not been set to UTC.
