### PR TITLE
show toast when working with AsyncTaskWithDialog

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/task/AsyncTaskWithDialog.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/task/AsyncTaskWithDialog.java
@@ -83,9 +83,7 @@ public abstract class AsyncTaskWithDialog<Params, Progress, Result> extends Asyn
                     message = RapidFtrApplication.getApplicationInstance().getString(defaultFailureMessage);
                 }
 
-                RapidFtrApplication.getApplicationInstance()
-                        .showNotification(notificationId,
-                                context.getString(R.string.info), message);
+                Toast.makeText(RapidFtrApplication.getApplicationInstance(), message, Toast.LENGTH_LONG).show();
             }
 
             public void cancel() {


### PR DESCRIPTION
When working on issue #30 we had introduced the android notifications when performing synchronisation how this affected some other operations e.g. when saving an empty form. The section of the code that affected this operation has been restored to use toasts.
