### PR TITLE
Fixes issue #37 - synch dialog box crashing.

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/service/ChildSyncService.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/service/ChildSyncService.java
@@ -185,8 +185,12 @@ public class ChildSyncService implements SyncService<Child> {
     }
 
     public HttpResponse getPhoto(Child child, String fileName) throws IOException {
+        String photoUrl =
+                String.format("/children/%s/photo/%s/resized/%sx%s",
+                        child.optString("_id"), fileName, PhotoCaptureHelper.PHOTO_WIDTH, PhotoCaptureHelper.PHOTO_HEIGHT);
+
         return fluentRequest
-                .path(String.format("/api/children/%s/photo/%s", child.optString("_id"), fileName))
+                .path(photoUrl)
                 .context(context)
                 .get();
     }


### PR DESCRIPTION
This fix changes the photo request url to the server to request for a resided photo. Previsiouly the dialog would hang because the client would run out of memory when processing large photos from the server.
The request to the server now includes a custom size for the picture that the server will return.
