### PR TITLE
enter and search multi-lingual data

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
@@ -82,7 +82,7 @@ public class ChildRepository implements Closeable, Repository<Child> {
         highlightedFields = (highlightedFields == null) ? Collections.EMPTY_LIST : highlightedFields;
         String query = buildSQLQueryForSearch(searchString, RapidFtrApplication.getApplicationInstance());
         @Cleanup Cursor cursor = session.rawQuery(query, null);
-        return filterByHighlightedFields(cursor, searchString, highlightedFields);
+        return filterChildrenWithRegularExpression(cursor, searchString, highlightedFields);
     }
 
     private String buildSQLQueryForSearch(String searchString, RapidFtrApplication context) throws JSONException {
@@ -97,9 +97,9 @@ public class ChildRepository implements Closeable, Repository<Child> {
         return queryBuilder.append(")").toString();
     }
 
-    private List<Child> filterByHighlightedFields(Cursor cursor, String searchString, List<FormField> highlightedFields) throws JSONException {
+    private List<Child> filterChildrenWithRegularExpression(Cursor cursor, String filterString, List<FormField> highlightedFields) throws JSONException {
         List<Child> children = new ArrayList<Child>();
-        Pattern pattern = buildPatternFromSearchString(searchString);
+        Pattern pattern = buildPatternFromSearchString(filterString);
 
         while (cursor.moveToNext()) {
             Child child = childFrom(cursor);

--- a/RapidFTR-Android/src/main/java/com/rapidftr/utils/http/FluentRequest.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/utils/http/FluentRequest.java
@@ -18,7 +18,6 @@ import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ByteArrayBody;
@@ -37,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.*;
 
@@ -155,7 +155,7 @@ public class FluentRequest {
             while(keys.hasNext())
             {
                 String currentKey = keys.next().toString();
-                multipartEntity.addPart(modelType+"["+currentKey+"]", new StringBody(baseModel.get(currentKey).toString()));
+                multipartEntity.addPart(modelType+"["+currentKey+"]", new StringBody(baseModel.get(currentKey).toString(), Charset.defaultCharset()));
             }
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/RapidFTR-Android/src/test/java/com/rapidftr/repository/ChildRepositoryTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/repository/ChildRepositoryTest.java
@@ -53,7 +53,7 @@ public class ChildRepositoryTest {
 
         highlightedFormFields = new ArrayList<FormField>();
         List<FormSection> formSections = FormSectionTest.loadFormSectionsFromClassPathResource();
-        for(FormSection formSection : formSections) {
+        for (FormSection formSection : formSections) {
             highlightedFormFields.addAll(formSection.getOrderedHighLightedFields());
         }
     }
@@ -152,7 +152,7 @@ public class ChildRepositoryTest {
         Child child2 = new Child("id2", "user2", "{ 'name' : 'child2', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
         Child child3 = new Child("id3", "user3", "{ 'name' : 'child3', 'test2' :  'child1', 'test3' : [ '1', 2, '3' ], \"x\": \"y\" }");
         Child child4 = new Child("child1", "user4", "{ 'name' : 'child4', 'test2' :  'test2', 'test3' : [ '1', 2, '3' ] }");
-        Child child5 = new Child("child1", "user5", "{ 'name' : 'child4 developer', 'test2' :  'test2', 'test3' : [ '1', 2, '3' ] }");
+        Child child5 = new Child("child2", "user5", "{ 'name' : 'child4 developer', 'test2' :  'test2', 'test3' : [ '1', 2, '3' ] }");
 
         repository.createOrUpdate(child1);
         repository.createOrUpdate(child2);
@@ -164,7 +164,7 @@ public class ChildRepositoryTest {
         assertEquals(1, children.size());
 
         children = repository.getMatchingChildren("hiLd", highlightedFormFields);
-        assertEquals(4, children.size());
+        assertEquals(5, children.size());
 
         children = repository.getMatchingChildren("hiLd1", highlightedFormFields);
         assertEquals(2, children.size());
@@ -187,6 +187,24 @@ public class ChildRepositoryTest {
 
         children = repository.getMatchingChildren("sam", highlightedFormFields);
         assertEquals(0, children.size());
+    }
+    
+    @Test
+    public void shouldReturnMatchedChildRecordsWithAccentedCharacters() throws JSONException {
+        Child child1 = new Child("id1", "user1", "{ 'name' : 'child1', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
+        Child child2 = new Child("id2", "user2", "{ 'name' : 'child2', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
+        Child child3 = new Child("id3", "user3", "{ 'name' : 'chåld3', 'test2' :  'child1', 'test3' : [ '1', 2, '3' ], \"x\": \"y\" }");
+        Child child4 = new Child("child1", "user4", "{ 'name' : 'chåld4', 'test2' :  'test2', 'test3' : [ '1', 2, '3' ] }");
+        Child child5 = new Child("child2", "user5", "{ 'name' : 'child4 developer', 'test2' :  'test2', 'test3' : [ '1', 2, '3' ] }");
+
+        repository.createOrUpdate(child1);
+        repository.createOrUpdate(child2);
+        repository.createOrUpdate(child3);
+        repository.createOrUpdate(child4);
+        repository.createOrUpdate(child5);
+
+        List<Child> children = repository.getMatchingChildren("chåld", highlightedFormFields);
+        assertEquals(2, children.size());
     }
 
     @Test


### PR DESCRIPTION
@ctumwebaze @mwangiann rapidftr/tracker#47 enter and search multi-lingual data

entering and searching multi-lingual data worked out of the box. The mingled character issues
was due to encoding data during the sync process.
When a sync request to push data to the server was constructed, the proper endcoding was not provided when
constructing the body of the request and this caused the special characters like the accent characters to get
replaced with question marks or boxes.

The solution to this was to specify the default encoding which is utf-8 on android.
