### PR TITLE
rapidftr/tracker#131 Limit search to Short ID

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
@@ -103,7 +103,7 @@ public class ChildRepository implements Closeable, Repository<Child> {
 
         while (cursor.moveToNext()) {
             Child child = childFrom(cursor);
-            if (pattern.matcher(child.getUniqueId()).matches()) {
+            if (pattern.matcher(child.getShortId()).matches()) {
                 children.add(child);
             } else {
                 for (FormField formField : highlightedFields) {

--- a/RapidFTR-Android/src/test/java/com/rapidftr/repository/ChildRepositoryTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/repository/ChildRepositoryTest.java
@@ -176,8 +176,9 @@ public class ChildRepositoryTest {
     @Test
     public void shouldMatchIndependentOfSearchTermOrder() throws JSONException, IOException {
         Child child1 = new Child("id1", "user1", "{ 'name' : 'first second', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
-        Child child2 = new Child("id1", "user1", "{ 'name' : 'john smith', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
+        Child child2 = new Child("id2", "user1", "{ 'name' : 'john smith', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
         repository.createOrUpdate(child1);
+        repository.createOrUpdate(child2);
 
         List<Child> children = repository.getMatchingChildren("first second", highlightedFormFields);
         assertEquals(1, children.size());
@@ -188,6 +189,22 @@ public class ChildRepositoryTest {
         children = repository.getMatchingChildren("sam", highlightedFormFields);
         assertEquals(0, children.size());
     }
+
+
+    @Test
+    public void shouldMatchOnlyShortId() throws JSONException, IOException {
+        String childId = "abcdefghijklmnop";
+        String childShortId = "jklmnop";
+        Child child1 = new Child(childId, "user1", "{ 'name' : 'first second', 'test2' : 0, 'test3' : [ '1', 2, '3' ] }");
+        repository.createOrUpdate(child1);
+
+        List<Child> children = repository.getMatchingChildren(childId, highlightedFormFields);
+        assertEquals(0, children.size());
+
+        children = repository.getMatchingChildren(childShortId, highlightedFormFields);
+        assertEquals(1, children.size());
+    }
+
 
     @Test
     public void shouldNotReturnChildrenCreatedByOtherUnAuthorizedUsers() throws Exception {


### PR DESCRIPTION
This pull request limits the Android search to only the Short ID, since that is what the user sees (instead of the full id).
