### PR TITLE
synchronising enquiries to the server

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/BaseEnquiryActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/BaseEnquiryActivity.java
@@ -8,7 +8,6 @@ import com.rapidftr.model.BaseModel;
 import com.rapidftr.model.Enquiry;
 import com.rapidftr.repository.EnquiryRepository;
 import com.rapidftr.task.AsyncTaskWithDialog;
-import lombok.Cleanup;
 import org.json.JSONException;
 
 import java.io.IOException;
@@ -42,7 +41,6 @@ public abstract class BaseEnquiryActivity extends CollectionActivity {
     protected Enquiry loadEnquiry(Bundle bundle, EnquiryRepository enquiryRepository) throws JSONException {
         String enquiryId = bundle.getString("id");
         Enquiry retrievedEnquiry = enquiryRepository.get(enquiryId);
-        enquiryRepository.close();
 
         return retrievedEnquiry;
     }
@@ -91,12 +89,11 @@ public abstract class BaseEnquiryActivity extends CollectionActivity {
     }
 
     private Enquiry saveEnquiry() throws Exception {
-        @Cleanup EnquiryRepository repository = inject(EnquiryRepository.class);
         if (enquiry.isNew()) {
             enquiry.setCreatedBy(getCurrentUser().getUserName());
             enquiry.setOrganisation(getCurrentUser().getOrganisation());
         }
-        repository.createOrUpdate(enquiry);
+        enquiryRepository.createOrUpdate(enquiry);
         return enquiry;
     }
 }

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewAllEnquiryActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewAllEnquiryActivity.java
@@ -4,19 +4,14 @@ import android.widget.ListView;
 import com.rapidftr.R;
 import com.rapidftr.adapter.EnquiryViewAdapter;
 import com.rapidftr.model.Enquiry;
-import com.rapidftr.repository.EnquiryRepository;
-import lombok.Cleanup;
 import org.json.JSONException;
-import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ViewAllEnquiryActivity extends BaseEnquiryActivity {
     @Override
     protected void initializeView() {
         setContentView(R.layout.activity_view_all_enquiries);
-        @Cleanup EnquiryRepository enquiryRepository = inject(EnquiryRepository.class);
         try {
             List<Enquiry> enquiries = enquiryRepository.all();
             listView(enquiries);

--- a/RapidFTR-Android/src/main/java/com/rapidftr/database/SQLCipherSession.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/database/SQLCipherSession.java
@@ -4,9 +4,11 @@ import lombok.Delegate;
 import lombok.RequiredArgsConstructor;
 import net.sqlcipher.database.SQLiteDatabase;
 
+
 @RequiredArgsConstructor(suppressConstructorProperties = true)
 public class SQLCipherSession implements DatabaseSession {
 
     @Delegate(types = DatabaseSession.class)
     protected final SQLiteDatabase database;
+
 }

--- a/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/repository/ChildRepository.java
@@ -240,7 +240,7 @@ public class ChildRepository implements Closeable, Repository<Child> {
     public List<Child> getAllWithInternalIds(List<String> internalIds) throws JSONException {
         List<Child> children = new ArrayList<Child>();
         for (String internalId : internalIds) {
-            Cursor cursor = session.rawQuery("SELECT child_json, synced FROM children WHERE _id = ?", new String[]{internalId});
+            @Cleanup Cursor cursor = session.rawQuery("SELECT child_json, synced FROM children WHERE _id = ?", new String[]{internalId});
             if (cursor.moveToNext())
                 children.add(childFrom(cursor));
         }

--- a/RapidFTR-Android/src/main/java/com/rapidftr/repository/EnquiryRepository.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/repository/EnquiryRepository.java
@@ -3,6 +3,7 @@ package com.rapidftr.repository;
 import android.content.ContentValues;
 import android.database.Cursor;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.rapidftr.database.Database;
 import com.rapidftr.database.DatabaseSession;
@@ -21,6 +22,7 @@ import static com.rapidftr.database.Database.EnquiryTableColumn.*;
 import static com.rapidftr.database.Database.enquiry;
 import static java.lang.String.format;
 
+@Singleton
 public class EnquiryRepository implements Closeable, Repository<Enquiry> {
 
     private final String user;

--- a/RapidFTR-Android/src/main/java/com/rapidftr/service/EnquirySyncService.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/service/EnquirySyncService.java
@@ -8,8 +8,6 @@ import com.rapidftr.model.Enquiry;
 import com.rapidftr.model.User;
 import com.rapidftr.repository.EnquiryRepository;
 import com.rapidftr.utils.RapidFtrDateTime;
-import com.rapidftr.utils.http.FluentResponse;
-import lombok.Cleanup;
 import org.apache.http.HttpException;
 import org.joda.time.DateTime;
 import org.json.JSONException;
@@ -47,10 +45,9 @@ public class EnquirySyncService implements SyncService<Enquiry> {
             record.setSynced(false);
             record.setLastUpdatedAt(null);
             enquiryRepository.update(record);
-            enquiryRepository.close();
             throw new SyncFailedException(exception.getMessage());
         }
-        enquiryRepository.close();
+
         return record;
     }
 

--- a/RapidFTR-Android/src/main/java/com/rapidftr/task/SyncSingleRecordTask.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/task/SyncSingleRecordTask.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
 import com.google.inject.Inject;
+import com.rapidftr.RapidFtrApplication;
 import com.rapidftr.model.BaseModel;
 import com.rapidftr.model.User;
 import com.rapidftr.repository.Repository;
@@ -13,9 +14,9 @@ import static com.rapidftr.RapidFtrApplication.APP_IDENTIFIER;
 
 public class SyncSingleRecordTask extends AsyncTaskWithDialog<BaseModel, Void, Boolean> {
 
-    protected  SyncService service;
-    protected  Repository repository;
-    protected  User currentUser;
+    protected SyncService service;
+    protected Repository repository;
+    protected User currentUser;
     private Activity activity;
 
     @Inject
@@ -32,6 +33,7 @@ public class SyncSingleRecordTask extends AsyncTaskWithDialog<BaseModel, Void, B
             return true;
         } catch (Exception e) {
             Log.e(APP_IDENTIFIER, "Error syncing one child record", e);
+            ((RapidFtrApplication) activity.getApplication()).showNotification(service.getNotificationId(), service.getNotificationTitle(), e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
@ctumwebaze @mwangiann rapidftr/tracker#162 

This issue was due to a database error. After a successful sync with the server, the synched record
could not be saved because the database was not open and therefore the state of the local record could not be updated to synched.
however, the record is saved on the server.
Subsequent synchronization for this record failed because the client attempts to have the record created on the client yet it already exists
so the server responds with a forbidden response code.

to fix this, we ensured there was a singleton instance of the EnquiryRepository and removed any calls to the close method of the repository
thus ensuring that the database is never closed by anyone using the same reference of the repository.
