### PR TITLE
rapidftr/tracker#201 @ctumwebaze @mwangiann listing potential matches

### DIFF
--- a/RapidFTR-Android/res/layout/child_list.xml
+++ b/RapidFTR-Android/res/layout/child_list.xml
@@ -2,6 +2,6 @@
 
 <ListView
         android:id="@+id/child_list"
-        android:layout_height="wrap_content" android:layout_width="fill_parent"
+        android:layout_height="match_parent" android:layout_width="fill_parent"
         xmlns:android="http://schemas.android.com/apk/res/android">
 </ListView>

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
@@ -21,8 +21,6 @@ import com.rapidftr.service.ChildSyncService;
 import com.rapidftr.service.LogOutService;
 import com.rapidftr.task.AsyncTaskWithDialog;
 import com.rapidftr.task.SyncSingleRecordTask;
-import com.rapidftr.utils.http.FluentRequest;
-import com.rapidftr.view.FormSectionView;
 import com.rapidftr.view.PotentialMatchesFormSectionView;
 import org.json.JSONException;
 
@@ -61,10 +59,10 @@ public class ViewChildActivity extends BaseChildActivity {
 
     @Override
     protected void initializePager() {
-        FormSectionView potentialMatchesView = new PotentialMatchesFormSectionView(this) {
+        PotentialMatchesFormSectionView potentialMatchesView = new PotentialMatchesFormSectionView(this) {
             @Override
             protected HighlightedFieldsViewAdapter getHighlightedFieldsViewAdapter(List<BaseModel> models) {
-                return new HighlightedFieldsViewAdapter(getContext(), models, Enquiry.ENQUIRY_FORM_NAME, ViewEnquiryActivity.class);
+                return new HighlightedFieldsViewAdapter(ViewChildActivity.this, models, Enquiry.ENQUIRY_FORM_NAME, ViewEnquiryActivity.class);
             }
         };
         getPager().setAdapter(new PotentialMatchesFormSectionPagerAdapter(formSections, getModel(), getEditable(), potentialMatchesView));

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewEnquiryActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewEnquiryActivity.java
@@ -18,7 +18,6 @@ import com.rapidftr.service.EnquirySyncService;
 import com.rapidftr.service.LogOutService;
 import com.rapidftr.task.AsyncTaskWithDialog;
 import com.rapidftr.task.SyncSingleRecordTask;
-import com.rapidftr.view.FormSectionView;
 import com.rapidftr.view.PotentialMatchesFormSectionView;
 import lombok.Cleanup;
 import org.json.JSONException;
@@ -35,10 +34,10 @@ public class ViewEnquiryActivity extends BaseEnquiryActivity {
 
     @Override
     protected void initializePager() {
-        FormSectionView potentialMatchesView = new PotentialMatchesFormSectionView(this) {
+        PotentialMatchesFormSectionView potentialMatchesView = new PotentialMatchesFormSectionView(this) {
             @Override
             protected HighlightedFieldsViewAdapter getHighlightedFieldsViewAdapter(List<BaseModel> models) {
-                return new HighlightedFieldsViewAdapter(getContext(), models, Child.CHILD_FORM_NAME, ViewChildActivity.class);
+                return new HighlightedFieldsViewAdapter(ViewEnquiryActivity.this, models, Child.CHILD_FORM_NAME, ViewChildActivity.class);
             }
         };
         getPager().setAdapter(new PotentialMatchesFormSectionPagerAdapter(formSections, getModel(), getEditable(), potentialMatchesView));

--- a/RapidFTR-Android/src/main/java/com/rapidftr/adapter/FormSectionPagerAdapter.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/adapter/FormSectionPagerAdapter.java
@@ -5,7 +5,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import com.rapidftr.forms.FormSection;
 import com.rapidftr.model.BaseModel;
-import com.rapidftr.view.FormSectionView;
+import com.rapidftr.view.DefaultFormSectionView;
 import lombok.AllArgsConstructor;
 
 import java.util.List;
@@ -29,15 +29,15 @@ public class FormSectionPagerAdapter extends PagerAdapter {
 
     @Override
     public Object instantiateItem(ViewGroup container, int position) {
-        FormSectionView view = createFormSectionView(container);
+        DefaultFormSectionView view = createFormSectionView(container);
         view.initialize(formSections.get(position), baseModel);
         view.setEnabled(editable);
         container.addView(view, 0);
         return view;
     }
 
-    protected FormSectionView createFormSectionView(ViewGroup container) {
-        return new FormSectionView(container.getContext());
+    protected DefaultFormSectionView createFormSectionView(ViewGroup container) {
+        return new DefaultFormSectionView(container.getContext());
     }
 
     @Override

--- a/RapidFTR-Android/src/main/java/com/rapidftr/adapter/PotentialMatchesFormSectionPagerAdapter.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/adapter/PotentialMatchesFormSectionPagerAdapter.java
@@ -5,16 +5,17 @@ import android.view.ViewGroup;
 import com.rapidftr.forms.FormSection;
 import com.rapidftr.forms.PotentialMatchesFormSection;
 import com.rapidftr.model.BaseModel;
-import com.rapidftr.view.FormSectionView;
+import com.rapidftr.view.DefaultFormSectionView;
 import com.rapidftr.view.PotentialMatchesFormSectionView;
 
 import java.util.List;
 
 public class PotentialMatchesFormSectionPagerAdapter extends FormSectionPagerAdapter {
 
-    private FormSectionView potentialMatchesView;
+    private PotentialMatchesFormSectionView potentialMatchesView;
 
-    public PotentialMatchesFormSectionPagerAdapter(List<FormSection> formSections, BaseModel baseModel, boolean editable, FormSectionView potentialMatchesView) {
+    public PotentialMatchesFormSectionPagerAdapter(List<FormSection> formSections, BaseModel baseModel, boolean editable,
+                                                   PotentialMatchesFormSectionView potentialMatchesView) {
         super(formSections, baseModel, editable);
         this.potentialMatchesView = potentialMatchesView;
     }
@@ -32,15 +33,17 @@ public class PotentialMatchesFormSectionPagerAdapter extends FormSectionPagerAda
     @Override
     public Object instantiateItem(ViewGroup container, int position) {
         FormSection formSection = formSections.get(position);
-        FormSectionView view;
+        View view = null;
 
         if (formSection instanceof PotentialMatchesFormSection) {
+            potentialMatchesView.initialize(formSection, baseModel);
             view = potentialMatchesView;
         } else {
-            view = createFormSectionView(container);
+            DefaultFormSectionView defaultFormSectionView = createFormSectionView(container);
+            defaultFormSectionView.initialize(formSection, baseModel);
+            view = defaultFormSectionView;
         }
 
-        view.initialize(formSection, baseModel);
         view.setEnabled(editable);
         container.addView(view, 0);
         return view;

--- a/RapidFTR-Android/src/main/java/com/rapidftr/view/DefaultFormSectionView.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/view/DefaultFormSectionView.java
@@ -1,0 +1,98 @@
+package com.rapidftr.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import com.rapidftr.R;
+import com.rapidftr.forms.FormField;
+import com.rapidftr.forms.FormSection;
+import com.rapidftr.model.BaseModel;
+import com.rapidftr.view.fields.BaseView;
+
+public class DefaultFormSectionView extends ScrollView implements FormSectionView {
+
+    private FormSection formSection;
+
+    private BaseModel model;
+
+    public DefaultFormSectionView(Context context) {
+        super(context);
+        inflateView(context);
+    }
+
+    public DefaultFormSectionView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        inflateView(context);
+    }
+
+    public DefaultFormSectionView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        inflateView(context);
+    }
+
+
+    private void inflateView(Context context) {
+        LayoutInflater layoutInflater = LayoutInflater.from(context);
+        layoutInflater.inflate(R.layout.form_section, this);
+    }
+
+    protected TextView getLabel() {
+        return (TextView) findViewById(R.id.label);
+    }
+
+    protected TextView getHelpText() {
+        return (TextView) findViewById(R.id.help_text);
+    }
+
+    protected LinearLayout getContainer() {
+        return (LinearLayout) findViewById(R.id.container);
+    }
+
+    public void initialize(FormSection formSection, BaseModel model) {
+        if (this.formSection != null)
+            throw new IllegalArgumentException("Form section is already initialized!");
+
+        this.formSection = formSection;
+        this.model = model;
+        this.initialize();
+    }
+
+    protected void initialize() {
+        getLabel().setText(formSection.getLocalizedName());
+        getHelpText().setText(formSection.getLocalizedHelpText());
+        for (FormField field : formSection.getFields()) {
+            BaseView fieldView = createFormField(field);
+            if (fieldView != null)
+                getContainer().addView(fieldView);
+        }
+    }
+
+    protected int getFieldLayoutId(String fieldType) {
+        return getResources().getIdentifier("form_" + fieldType, "layout", getContext().getPackageName());
+    }
+
+    protected BaseView createFormField(FormField field) {
+        int resourceId = getFieldLayoutId(field.getType());
+
+        if (resourceId > 0) {
+            BaseView fieldView = (BaseView) LayoutInflater.from(getContext()).inflate(resourceId, null);
+            fieldView.initialize(field, model);
+
+            return fieldView;
+        }
+
+        return null;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+
+        LinearLayout container = getContainer();
+        for (int i = 0, j = container.getChildCount(); i < j; i++)
+            container.getChildAt(i).setEnabled(enabled);
+    }
+}

--- a/RapidFTR-Android/src/main/java/com/rapidftr/view/FormSectionView.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/view/FormSectionView.java
@@ -1,98 +1,12 @@
 package com.rapidftr.view;
 
-import android.content.Context;
-import android.util.AttributeSet;
-import android.view.LayoutInflater;
-import android.widget.LinearLayout;
-import android.widget.ScrollView;
-import android.widget.TextView;
-import com.rapidftr.R;
-import com.rapidftr.forms.FormField;
 import com.rapidftr.forms.FormSection;
 import com.rapidftr.model.BaseModel;
-import com.rapidftr.view.fields.BaseView;
 
-public class FormSectionView extends ScrollView {
+public interface FormSectionView  {
 
-    private FormSection formSection;
+    public void initialize(FormSection formSection, BaseModel model);
 
-    private BaseModel model;
+    public void setEnabled(boolean enabled);
 
-    public FormSectionView(Context context) {
-        super(context);
-        inflateView(context);
-    }
-
-    public FormSectionView(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        inflateView(context);
-    }
-
-    public FormSectionView(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs, defStyle);
-        inflateView(context);
-    }
-
-
-    private void inflateView(Context context) {
-        LayoutInflater layoutInflater = LayoutInflater.from(context);
-        layoutInflater.inflate(R.layout.form_section, this);
-    }
-
-    protected TextView getLabel() {
-        return (TextView) findViewById(R.id.label);
-    }
-
-    protected TextView getHelpText() {
-        return (TextView) findViewById(R.id.help_text);
-    }
-
-    protected LinearLayout getContainer() {
-        return (LinearLayout) findViewById(R.id.container);
-    }
-
-    public void initialize(FormSection formSection, BaseModel model) {
-        if (this.formSection != null)
-            throw new IllegalArgumentException("Form section is already initialized!");
-
-        this.formSection = formSection;
-        this.model = model;
-        this.initialize();
-    }
-
-    protected void initialize() {
-        getLabel().setText(formSection.getLocalizedName());
-        getHelpText().setText(formSection.getLocalizedHelpText());
-        for (FormField field : formSection.getFields()) {
-            BaseView fieldView = createFormField(field);
-            if (fieldView != null)
-                getContainer().addView(fieldView);
-        }
-    }
-
-    protected int getFieldLayoutId(String fieldType) {
-        return getResources().getIdentifier("form_" + fieldType, "layout", getContext().getPackageName());
-    }
-
-    protected BaseView createFormField(FormField field) {
-        int resourceId = getFieldLayoutId(field.getType());
-
-        if (resourceId > 0) {
-            BaseView fieldView = (BaseView) LayoutInflater.from(getContext()).inflate(resourceId, null);
-            fieldView.initialize(field, model);
-
-            return fieldView;
-        }
-
-        return null;
-    }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        super.setEnabled(enabled);
-
-        LinearLayout container = getContainer();
-        for (int i = 0, j = container.getChildCount(); i < j; i++)
-            container.getChildAt(i).setEnabled(enabled);
-    }
 }

--- a/RapidFTR-Android/src/main/java/com/rapidftr/view/PotentialMatchesFormSectionView.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/view/PotentialMatchesFormSectionView.java
@@ -5,7 +5,10 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.TextView;
 import com.rapidftr.R;
 import com.rapidftr.RapidFtrApplication;
 import com.rapidftr.adapter.HighlightedFieldsViewAdapter;
@@ -20,18 +23,28 @@ import org.json.JSONException;
 
 import java.util.List;
 
-public abstract class PotentialMatchesFormSectionView extends FormSectionView {
+public abstract class PotentialMatchesFormSectionView extends LinearLayout implements FormSectionView {
 
     public PotentialMatchesFormSectionView(Context context) {
         super(context);
+        this.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        initializeView(context);
     }
 
     public PotentialMatchesFormSectionView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initializeView(context);
     }
 
     public PotentialMatchesFormSectionView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        initializeView(context);
+    }
+
+    private void initializeView(Context context) {
+        this.setOrientation(LinearLayout.VERTICAL);
+        LayoutInflater layoutInflater = LayoutInflater.from(context);
+        layoutInflater.inflate(R.layout.form_section, this);
     }
 
     @Override
@@ -45,11 +58,24 @@ public abstract class PotentialMatchesFormSectionView extends FormSectionView {
 
             try {
                 List<BaseModel> potentialMatches = model.getPotentialMatchingModels(potentialMatchRepository, childRepository, enquiryRepository);
+                getContainer().removeAllViews();
                 getContainer().addView(createPotentialMatchView(getContext(), potentialMatches));
             } catch (JSONException e) {
                 Log.e(null, null, e);
             }
         }
+    }
+
+    protected LinearLayout getContainer() {
+        return (LinearLayout) findViewById(R.id.container);
+    }
+
+    protected TextView getLabel() {
+        return (TextView) findViewById(R.id.label);
+    }
+
+    protected TextView getHelpText() {
+        return (TextView) findViewById(R.id.help_text);
     }
 
     private View createPotentialMatchView(Context context, List<BaseModel> models) {

--- a/RapidFTR-Android/src/test/java/com/rapidftr/adapter/FormSectionPagerAdapterTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/adapter/FormSectionPagerAdapterTest.java
@@ -5,7 +5,7 @@ import android.view.ViewGroup;
 import com.rapidftr.CustomTestRunner;
 import com.rapidftr.forms.FormSection;
 import com.rapidftr.model.Child;
-import com.rapidftr.view.FormSectionView;
+import com.rapidftr.view.DefaultFormSectionView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,7 +38,7 @@ public class FormSectionPagerAdapterTest {
 
     @Test
     public void testInstantiateEnabledItem() {
-        FormSectionView view = mock(FormSectionView.class);
+        DefaultFormSectionView view = mock(DefaultFormSectionView.class);
         ViewGroup container = mock(ViewGroup.class);
 
         doReturn(view).when(adapter).createFormSectionView(container);
@@ -51,7 +51,7 @@ public class FormSectionPagerAdapterTest {
 
     @Test
     public void testInstantiateDisabledItem() {
-        FormSectionView view = mock(FormSectionView.class);
+        DefaultFormSectionView view = mock(DefaultFormSectionView.class);
         ViewGroup container = mock(ViewGroup.class);
 
         doReturn(view).when(adapter).createFormSectionView(container);
@@ -65,7 +65,7 @@ public class FormSectionPagerAdapterTest {
 
     @Test
     public void shouldReturnViewAsKey() {
-        FormSectionView view = mock(FormSectionView.class);
+        DefaultFormSectionView view = mock(DefaultFormSectionView.class);
         doReturn(view).when(adapter).createFormSectionView(any(ViewGroup.class));
 
         Object actual = adapter.instantiateItem(mock(ViewGroup.class), 0);

--- a/RapidFTR-Android/src/test/java/com/rapidftr/view/FormSectionViewTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/view/FormSectionViewTest.java
@@ -1,9 +1,7 @@
 package com.rapidftr.view;
 
 import android.app.Activity;
-import android.view.LayoutInflater;
 import com.rapidftr.CustomTestRunner;
-import com.rapidftr.R;
 import com.rapidftr.activity.RegisterChildActivity;
 import com.rapidftr.forms.FormField;
 import com.rapidftr.forms.FormSection;
@@ -14,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +27,7 @@ import static org.mockito.Mockito.verify;
 @RunWith(CustomTestRunner.class)
 public class FormSectionViewTest {
 
-    private FormSectionView view;
+    private DefaultFormSectionView view;
     private FormSection section;
     private FormField field;
     private Child child;
@@ -38,7 +35,7 @@ public class FormSectionViewTest {
     @Before
     public void setUp() throws JSONException {
         Activity activity = Robolectric.buildActivity(RegisterChildActivity.class).create().get();
-        view = new FormSectionView(activity);
+        view = new DefaultFormSectionView(activity);
         child = new Child();
 
         section = new FormSection();


### PR DESCRIPTION
The reason why the pontential matches view was displaying a single record was because of embedding a listview in a scrollview.
This PotentialMatchesView was inheriting a FormSectionView which was inheriting a ScrollView. What this fix does is to alter the inheritance change and only make the FormSectionView (Now DefaultFormSectionView) inherit from a ScrollView and the PotentialMatchesView inherit from a LinearLayout.
