### PR TITLE
 ensure that unverified users highlighted fields don't display null.

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/RapidFtrApplication.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/RapidFtrApplication.java
@@ -197,4 +197,14 @@ public class RapidFtrApplication extends Application {
     public void cancelNotification(int notificationId) {
         notificationManager.cancel(notificationId);
     }
+
+    public String getLanguageOfCurrentUser() {
+        String languageCode = getCurrentUser().getLanguage();
+
+        if (languageCode == null || languageCode.trim().length() == 0) {
+            languageCode = "en";
+        }
+
+        return languageCode;
+    }
 }

--- a/RapidFTR-Android/src/main/java/com/rapidftr/view/HighlightedFieldViewGroup.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/view/HighlightedFieldViewGroup.java
@@ -42,7 +42,7 @@ public class HighlightedFieldViewGroup extends LinearLayout {
 
             if (StringUtils.isNotEmpty(baseModel.optString(highlightedFields.get(fieldId).getId()))) {
                 String fieldValue = String.format("%s: %s",
-                        highlightedFields.get(fieldId).getDisplayName().get(RapidFtrApplication.getApplicationInstance().getCurrentUser().getLanguage()),
+                        highlightedFields.get(fieldId).getDisplayName().get(RapidFtrApplication.getApplicationInstance().getLanguageOfCurrentUser()),
                         baseModel.optString(highlightedFields.get(fieldId).getId()));
 
                 textView.setText(fieldValue);

--- a/RapidFTR-Android/src/test/java/com/rapidftr/RapidFtrApplicationTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/RapidFtrApplicationTest.java
@@ -14,8 +14,8 @@ import java.io.IOException;
 
 import static com.rapidftr.CustomTestRunner.createUser;
 import static com.rapidftr.RapidFtrApplication.SERVER_URL_PREF;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.*;
 
 @RunWith(CustomTestRunner.class)
@@ -28,14 +28,14 @@ public class RapidFtrApplicationTest {
         application = spy(new RapidFtrApplication(CustomTestRunner.INJECTOR));
     }
 
-	@Test
-	public void shouldSaveServerUrlAfterSuccessfulLogin() throws IOException {
-		User user = createUser();
-		user.setServerUrl("http://test-server-url");
-		application.setCurrentUser(user);
+    @Test
+    public void shouldSaveServerUrlAfterSuccessfulLogin() throws IOException {
+        User user = createUser();
+        user.setServerUrl("http://test-server-url");
+        application.setCurrentUser(user);
 
-		Assert.assertThat(application.getSharedPreferences().getString(SERVER_URL_PREF, ""), equalTo(user.getServerUrl()));
-	}
+        Assert.assertThat(application.getSharedPreferences().getString(SERVER_URL_PREF, ""), equalTo(user.getServerUrl()));
+    }
 
     @Test
     public void shouldCleanAsyncTask() {
@@ -51,28 +51,12 @@ public class RapidFtrApplicationTest {
         verify(mockNotification).cancel(SynchronisationAsyncTask.NOTIFICATION_ID);
     }
 
-//	@Test
-//	public void testInitializeFormSections() throws JSONException, IOException {
-//		List<FormSection> formSections = (List<FormSection>) mock(List.class);
-//		RapidFtrApplication.getApplicationInstance().setFormSections(formSections);
-//
-//		activity.initializeData(null);
-//		assertThat(activity.formSections, equalTo(formSections));
-//	}
+    @Test
+    public void shouldReturnEnglishForLanguageOfCurrentUserWithoutLanguage() {
+        User user = createUser();
+        user.setLanguage(null);
 
-
-//    @Test
-//    public void shouldReturnUserName() {
-//        application.setPreference(RapidFtrApplication.Preference.USER_NAME, "testUser");
-//        assertThat(application.getUserName(), equalTo("testUser"));
-//    }
-//
-//    @Test
-//    public void shouldReturnUserObject() throws JSONException {
-//        application.setPreference(RapidFtrApplication.Preference.USER_NAME, "testUser");
-//        application.setPreference("testUser", "{ 'abc' : 'xyz' }");
-//        User user = application.buildUser();
-//        assertThat(user.getString("abc"), equalTo("xyz"));
-//    }
-
+        application.setCurrentUser(user);
+        Assert.assertThat(application.getLanguageOfCurrentUser(), equalTo("en"));
+    }
 }


### PR DESCRIPTION
fix for rapidftr/tracker#291

Adds a method in the RapidFtrApplication class to return "en" as the default language when the language of the currently logged in user cannot be determined or is null.
