### PR TITLE
Hide matches when viewing child on rapidreg

### DIFF
--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/CollectionActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/CollectionActivity.java
@@ -6,8 +6,10 @@ import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.widget.*;
+import com.google.inject.Inject;
 import com.rapidftr.R;
 import com.rapidftr.adapter.FormSectionPagerAdapter;
+import com.rapidftr.features.FeatureToggle;
 import com.rapidftr.forms.FormSection;
 import com.rapidftr.model.BaseModel;
 import com.rapidftr.service.FormService;
@@ -25,6 +27,9 @@ public abstract class CollectionActivity extends RapidFtrActivity {
     @Getter
     @Setter
     MediaPlayer mediaPlayer;
+
+    @Inject
+    protected FeatureToggle featureToggle;
 
     protected FormService formService;
     protected List<FormSection> formSections;

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/RapidFtrActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/RapidFtrActivity.java
@@ -41,6 +41,7 @@ public abstract class RapidFtrActivity extends Activity {
 
     public static final String LOGOUT_INTENT_FILTER = "com.rapidftr.LOGOUT_INTENT";
 
+
     protected
     @Getter
     @Setter

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
@@ -1,6 +1,7 @@
 package com.rapidftr.activity;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
@@ -28,11 +29,13 @@ import com.rapidftr.view.PotentialMatchesFormSectionView;
 import com.rapidftr.view.PotentialMatchesViewAdapter;
 import lombok.Cleanup;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.rapidftr.RapidFtrApplication.APP_IDENTIFIER;
+import static com.rapidftr.RapidFtrApplication.SHARED_PREFERENCES_FILE;
 
 
 public class ViewChildActivity extends BaseChildActivity {
@@ -85,9 +88,14 @@ public class ViewChildActivity extends BaseChildActivity {
         super.initializeData(savedInstanceState);
         this.editable = false;
         load();
-        PotentialMatchesFormSection section = new PotentialMatchesFormSection();
-        section.setOrder(formSections.size());
-        formSections.add(section);
+
+        SharedPreferences sharedPreferences = getContext().getSharedPreferences();
+        JSONObject features = new JSONObject(sharedPreferences.getString("features", "{}"));
+        if (features.optBoolean("Enquiries", true)) {
+            PotentialMatchesFormSection section = new PotentialMatchesFormSection();
+            section.setOrder(formSections.size());
+            formSections.add(section);
+        }
     }
 
     protected void sync() {

--- a/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/activity/ViewChildActivity.java
@@ -13,6 +13,7 @@ import com.google.inject.Inject;
 import com.rapidftr.R;
 import com.rapidftr.RapidFtrApplication;
 import com.rapidftr.adapter.PotentialMatchesFormSectionPagerAdapter;
+import com.rapidftr.features.FEATURE;
 import com.rapidftr.forms.PotentialMatchesFormSection;
 import com.rapidftr.model.BaseModel;
 import com.rapidftr.model.Child;
@@ -89,9 +90,7 @@ public class ViewChildActivity extends BaseChildActivity {
         this.editable = false;
         load();
 
-        SharedPreferences sharedPreferences = getContext().getSharedPreferences();
-        JSONObject features = new JSONObject(sharedPreferences.getString("features", "{}"));
-        if (features.optBoolean("Enquiries", true)) {
+        if (featureToggle.isEnabled(FEATURE.ENQUIRIES)) {
             PotentialMatchesFormSection section = new PotentialMatchesFormSection();
             section.setOrder(formSections.size());
             formSections.add(section);

--- a/RapidFTR-Android/src/main/java/com/rapidftr/features/FEATURE.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/features/FEATURE.java
@@ -1,0 +1,5 @@
+package com.rapidftr.features;
+
+public enum FEATURE {
+    ENQUIRIES, CHILDREN
+}

--- a/RapidFTR-Android/src/main/java/com/rapidftr/features/FeatureToggle.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/features/FeatureToggle.java
@@ -1,0 +1,24 @@
+package com.rapidftr.features;
+
+import android.content.SharedPreferences;
+import com.google.inject.Inject;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class FeatureToggle {
+
+    private SharedPreferences sharedPreferences;
+
+    @Inject
+    public FeatureToggle(SharedPreferences sharedPreferences) {
+        this.sharedPreferences = sharedPreferences;
+    }
+
+    public boolean isEnabled(FEATURE feature) throws JSONException {
+        JSONObject features = new JSONObject(sharedPreferences.getString("features", "{}"));
+        if (features.optBoolean("Enquiries", true)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/RapidFTR-Android/src/main/java/com/rapidftr/service/FormService.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/service/FormService.java
@@ -25,7 +25,6 @@ import static com.rapidftr.utils.http.FluentRequest.http;
 public class FormService {
 
     public static final String FORM_SECTIONS_PREF = "FORM_SECTION";
-    public static final String DEFAULT_FORM_SECTIONS_FILE_NAME = "default_form_sections.json";
     public static final String API_FORM_SECTIONS_PATH = "/api/form_sections";
 
     private RapidFtrApplication context;

--- a/RapidFTR-Android/src/main/java/com/rapidftr/utils/ApplicationInjector.java
+++ b/RapidFTR-Android/src/main/java/com/rapidftr/utils/ApplicationInjector.java
@@ -11,6 +11,7 @@ import com.rapidftr.RapidFtrApplication;
 import com.rapidftr.database.DatabaseHelper;
 import com.rapidftr.database.DatabaseSession;
 import com.rapidftr.database.SQLCipherHelper;
+import com.rapidftr.features.FeatureToggle;
 import com.rapidftr.model.Child;
 import com.rapidftr.model.Enquiry;
 import com.rapidftr.model.PotentialMatch;
@@ -53,6 +54,7 @@ public class ApplicationInjector extends AbstractModule {
         bind(LogOutService.class);
         bind(LoginService.class);
         bind(DeviceService.class);
+        bind(FeatureToggle.class);
     }
 
     @Provides

--- a/RapidFTR-Android/src/test/java/com/rapidftr/features/FeatureToggleTest.java
+++ b/RapidFTR-Android/src/test/java/com/rapidftr/features/FeatureToggleTest.java
@@ -1,0 +1,61 @@
+package com.rapidftr.features;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import com.rapidftr.CustomTestRunner;
+import com.rapidftr.RapidFtrApplication;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+
+import static com.rapidftr.RapidFtrApplication.SHARED_PREFERENCES_FILE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(CustomTestRunner.class)
+public class FeatureToggleTest {
+
+    private RapidFtrApplication application;
+    private SharedPreferences mockSharedPreferences;
+
+    @Before
+    public void setUp() throws Exception {
+        application = mock(RapidFtrApplication.class);
+        mockSharedPreferences = Robolectric.application.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
+    }
+
+    @Test
+    public void shouldReturnTrueForBothChildrenAndEnquiriesGivenOnlyEnquiriesAreSpecified() throws JSONException {
+        mockSharedPreferences.edit().putString("features", "{\"Enquiries\":\"true\", \"Children\":\"true\"}").commit();
+        when(application.getSharedPreferences()).thenReturn(mockSharedPreferences);
+
+        FeatureToggle featureToggle = new FeatureToggle(mockSharedPreferences);
+
+        assertTrue(featureToggle.isEnabled(FEATURE.ENQUIRIES));
+        assertTrue(featureToggle.isEnabled(FEATURE.CHILDREN));
+    }
+
+    @Test
+    public void shouldReturnFalseGivenEnquiriesAreOff() throws JSONException {
+        mockSharedPreferences.edit().putString("features", "{\"Enquiries\":\"false\", \"Children\":\"true\"}").commit();
+        when(application.getSharedPreferences()).thenReturn(mockSharedPreferences);
+
+        FeatureToggle featureToggle = new FeatureToggle(mockSharedPreferences);
+
+        assertFalse(featureToggle.isEnabled(FEATURE.ENQUIRIES));
+    }
+
+    @Test
+    public void shouldReturnTrueForEnquiriesIfFeatureTogglesDontExist() throws JSONException {
+        when(application.getSharedPreferences()).thenReturn(mockSharedPreferences);
+
+        FeatureToggle featureToggle = new FeatureToggle(mockSharedPreferences);
+
+        assertTrue(featureToggle.isEnabled(FEATURE.ENQUIRIES));
+        assertTrue(featureToggle.isEnabled(FEATURE.CHILDREN));
+    }
+}


### PR DESCRIPTION
This pull request introduces a feature toggle class is going to house all the toggling logic going forward