### PR TITLE
Use android manifest merger to specify android version code at build time

### DIFF
--- a/RapidFTR-Android/pom.xml
+++ b/RapidFTR-Android/pom.xml
@@ -295,6 +295,19 @@
                     <renameManifestPackage>com.${brand}</renameManifestPackage>
                     <manifestApplicationLabel>${brand}</manifestApplicationLabel>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>manifest-merge</id>
+                        <goals>
+                            <goal>manifest-merger</goal>
+                        </goals>
+                        <configuration>
+                            <manifestMerger>
+                                <versionCode>${android.manifestMerger.versionCode}</versionCode>
+                            </manifestMerger>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -344,7 +357,9 @@
                                     <removeExistingSignatures>true</removeExistingSignatures>
                                     <archiveDirectory/>
                                     <includes>
-                                        <include>${project.build.directory}/${project.artifactId}-${project.version}.apk</include>
+                                        <include>
+                                            ${project.build.directory}/${project.artifactId}-${project.version}.apk
+                                        </include>
                                     </includes>
                                     <keystore>${keystore.file}</keystore>
                                     <storepass>${keystore.password}</storepass>
@@ -372,7 +387,8 @@
                             </sign>
                             <zipalign>
                                 <verbose>true</verbose>
-                                <inputApk>${project.build.directory}/${project.artifactId}-${project.version}.apk</inputApk>
+                                <inputApk>${project.build.directory}/${project.artifactId}-${project.version}.apk
+                                </inputApk>
                                 <outputApk>${project.build.directory}/${project.artifactId}-release.apk</outputApk>
                                 <skip>false</skip>
                             </zipalign>

--- a/RapidFTR-Android/src/main/AndroidManifest.xml
+++ b/RapidFTR-Android/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
                  android:label="@string/app_name"
                  android:theme="@style/Theme.RapidFTRtheme">
 
-        <meta-data android:name="device.wipe.flag" android:value="${device.wipe.flag}"/>
+        <meta-data android:name="device.wipe.flag" android:value="1"/>
 
         <activity android:name=".activity.DeviceAdminActivity" android:label="@string/app_name" android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>

--- a/RapidFTR-Android/travis/AndroidManifest.xml
+++ b/RapidFTR-Android/travis/AndroidManifest.xml
@@ -28,7 +28,7 @@
                  android:label="@string/app_name"
                  android:theme="@style/Theme.RapidFTRtheme">
 
-        <meta-data android:name="device.wipe.flag" android:value="${device.wipe.flag}"/>
+        <meta-data android:name="device.wipe.flag" android:value="1"/>
 
         <activity android:name=".activity.DeviceAdminActivity" android:label="RapidFTR" android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>

--- a/RapidFTR-Android/travis/initialize_android.sh
+++ b/RapidFTR-Android/travis/initialize_android.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-INITIALIZATION_FILE="$ANDROID_HOME/.initialized-dependencies-$(git log -n 1 --format=%h -- $0)"
+INITIALIZATION_FILE="$ANDROID_HOME/.initialized-dependencies-$(git log -n 1 --format=%h)"
 
 if [ ! -e ${INITIALIZATION_FILE} ]; then
   download-android
@@ -13,6 +13,9 @@ if [ ! -e ${INITIALIZATION_FILE} ]; then
   echo y | android update sdk --no-ui --filter extra-google-m2repository --all > /dev/null
   echo y | android update sdk --no-ui --filter extra-android-m2repository --all > /dev/null
   echo y | android update sdk --no-ui --filter sys-img-armeabi-v7a-android-15 --all > /dev/null
+
+  (wget http://dl.google.com/android/android-sdk_r23-linux.tgz -O - | tar zx -C $ANDROID_HOME --strip-components 1); echo
+  echo 'y' | $ANDROID_HOME/tools/android --silent update sdk --no-ui --force --all --obsolete --filter platform-tools
 
   touch ${INITIALIZATION_FILE}
 fi


### PR DESCRIPTION
Adds the option to specify the android version at build time using the property: `android.manifestMerger.versionCode`. More info [here](http://simpligility.github.io/android-maven-plugin/manifest-merger-mojo.html#manifestMerger)